### PR TITLE
feat(cms): FORGE-327 add embargo/unembargo all in folder context menu

### DIFF
--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoAllFolderDialog.html
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoAllFolderDialog.html
@@ -1,0 +1,27 @@
+<!--
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org/">
+<wicket:extend>
+    <wicket:child/>
+    <div class="hippo-dialog-body">
+        <div class="label" wicket:id="message"></div>
+        <div style="margin-top: 10px">
+            <input type="checkbox" wicket:id="recurse"/>
+            <label wicket:id="recurseLabel"></label>
+        </div>
+    </div>
+</wicket:extend>
+</html>

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoAllFolderDialog.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoAllFolderDialog.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onehippo.forge.embargo.frontend.plugins;
+
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.util.value.IValueMap;
+import org.hippoecm.addon.workflow.StdWorkflow;
+import org.hippoecm.frontend.dialog.Dialog;
+import org.hippoecm.frontend.dialog.DialogConstants;
+import org.hippoecm.repository.standardworkflow.FolderWorkflow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EmbargoAllFolderDialog extends Dialog<Boolean> {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbargoAllFolderDialog.class);
+
+    private final StdWorkflow<FolderWorkflow> action;
+    private final IModel<String> titleModel;
+
+    public EmbargoAllFolderDialog(final StdWorkflow<FolderWorkflow> action, final IModel<Boolean> recurseModel,
+                                   final IModel<String> titleModel, final IModel<String> messageModel) {
+        super(recurseModel);
+        this.titleModel = titleModel;
+        add(new Label("message", messageModel));
+        add(new CheckBox("recurse", recurseModel));
+        add(new Label("recurseLabel", new ResourceModel("recurse-sub-folders-label")));
+        this.action = action;
+    }
+
+    @Override
+    public IModel<String> getTitle() {
+        return titleModel;
+    }
+
+    @Override
+    public IValueMap getProperties() {
+        return DialogConstants.SMALL;
+    }
+
+    @Override
+    protected void onOk() {
+        try {
+            action.invokeWorkflow();
+        } catch (Exception e) {
+            log.error("Error invoking embargo all in folder workflow", e);
+        }
+    }
+}

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoAllFolderDialog.properties
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoAllFolderDialog.properties
@@ -1,0 +1,3 @@
+embargo-all-folder-title=Embargo all in folder
+embargo-all-confirm-text=This will embargo all documents in the selected folder.
+recurse-sub-folders-label=Include sub-folders

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoAllFolderDialog_nl.properties
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoAllFolderDialog_nl.properties
@@ -1,0 +1,3 @@
+embargo-all-folder-title=Embargo alles in map
+embargo-all-confirm-text=Dit zal embargo plaatsen op alle documenten in de geselecteerde map.
+recurse-sub-folders-label=Inclusief submappen

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoFolderWorkflowPlugin.html
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoFolderWorkflowPlugin.html
@@ -1,0 +1,21 @@
+<!--
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org/">
+<wicket:panel>
+    <div wicket:id="embargoAllMenuItem">[EMBARGO ALL IN FOLDER]</div>
+    <div wicket:id="unEmbargoAllMenuItem">[UNEMBARGO ALL IN FOLDER]</div>
+</wicket:panel>
+</html>

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoFolderWorkflowPlugin.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoFolderWorkflowPlugin.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onehippo.forge.embargo.frontend.plugins;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.Session;
+import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.model.StringResourceModel;
+import org.hippoecm.addon.workflow.StdWorkflow;
+import org.hippoecm.addon.workflow.WorkflowDescriptorModel;
+import org.hippoecm.frontend.dialog.IDialogService;
+import org.hippoecm.frontend.plugin.IPluginContext;
+import org.hippoecm.frontend.plugin.config.IPluginConfig;
+import org.hippoecm.frontend.plugins.standards.icon.HippoIcon;
+import org.hippoecm.frontend.service.render.RenderPlugin;
+import org.hippoecm.frontend.session.UserSession;
+import org.hippoecm.frontend.skin.Icon;
+import org.hippoecm.repository.api.HippoWorkspace;
+import org.hippoecm.repository.api.Workflow;
+import org.hippoecm.repository.api.WorkflowDescriptor;
+import org.hippoecm.repository.api.WorkflowManager;
+import org.hippoecm.repository.standardworkflow.FolderWorkflow;
+import org.onehippo.forge.embargo.repository.EmbargoConstants;
+import org.onehippo.forge.embargo.repository.EmbargoUtils;
+import org.onehippo.forge.embargo.repository.workflow.EmbargoWorkflow;
+import org.onehippo.repository.security.JvmCredentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Folder context-menu plugin that applies embargo to all unembargoed documents in the selected folder.
+ * Presents a confirmation dialog with an option to recurse into sub-folders.
+ * Appears only for users who belong to at least one embargo-enabled group (or are admins).
+ */
+public class EmbargoFolderWorkflowPlugin extends RenderPlugin<WorkflowDescriptor> {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbargoFolderWorkflowPlugin.class);
+
+    static {
+        log.warn("EMBARGO-DEBUG class loaded by classloader");
+    }
+
+    private final boolean userCanEmbargo;
+
+    private static IPluginContext logConstructorEntry(final IPluginContext context) {
+        log.warn("EMBARGO-DEBUG constructor entry (pre-super)");
+        return context;
+    }
+
+    public EmbargoFolderWorkflowPlugin(final IPluginContext context, final IPluginConfig config) {
+        super(logConstructorEntry(context), config);
+        log.warn("EMBARGO-DEBUG constructor post-super, defaultModel={}", getDefaultModel());
+        this.userCanEmbargo = currentUserCanEmbargo();
+        log.warn("EMBARGO-DEBUG userCanEmbargo={}", userCanEmbargo);
+        add(createEmbargoAllMenuItem());
+        add(createUnEmbargoAllMenuItem());
+    }
+
+    private StdWorkflow<FolderWorkflow> createEmbargoAllMenuItem() {
+        return new StdWorkflow<FolderWorkflow>("embargoAllMenuItem",
+                new StringResourceModel("embargo-all-in-folder-label", this, null),
+                getPluginContext(),
+                (WorkflowDescriptorModel) getDefaultModel()) {
+
+            public boolean recurseSubFolders = false;
+
+            @Override
+            protected void onConfigure() {
+                super.onConfigure();
+                setVisible(userCanEmbargo);
+            }
+
+            @Override
+            protected Component getIcon(final String id) {
+                return HippoIcon.fromSprite(id, Icon.LOCKED);
+            }
+
+            @Override
+            protected IDialogService.Dialog createRequestDialog() {
+                return new EmbargoAllFolderDialog(this, new PropertyModel<>(this, "recurseSubFolders"),
+                        new StringResourceModel("embargo-all-folder-title", EmbargoFolderWorkflowPlugin.this, null),
+                        new StringResourceModel("embargo-all-confirm-text", EmbargoFolderWorkflowPlugin.this, null));
+            }
+
+            @Override
+            protected String execute(final FolderWorkflow workflow) throws Exception {
+                applyEmbargoToFolderDocuments(recurseSubFolders);
+                return null;
+            }
+        };
+    }
+
+    private StdWorkflow<FolderWorkflow> createUnEmbargoAllMenuItem() {
+        return new StdWorkflow<FolderWorkflow>("unEmbargoAllMenuItem",
+                new StringResourceModel("unembargo-all-in-folder-label", this, null),
+                getPluginContext(),
+                (WorkflowDescriptorModel) getDefaultModel()) {
+
+            public boolean recurseSubFolders = false;
+
+            @Override
+            protected void onConfigure() {
+                super.onConfigure();
+                setVisible(userCanEmbargo);
+            }
+
+            @Override
+            protected Component getIcon(final String id) {
+                return HippoIcon.fromSprite(id, Icon.UNLOCKED);
+            }
+
+            @Override
+            protected IDialogService.Dialog createRequestDialog() {
+                return new EmbargoAllFolderDialog(this, new PropertyModel<>(this, "recurseSubFolders"),
+                        new StringResourceModel("unembargo-all-folder-title", EmbargoFolderWorkflowPlugin.this, null),
+                        new StringResourceModel("unembargo-all-confirm-text", EmbargoFolderWorkflowPlugin.this, null));
+            }
+
+            @Override
+            protected String execute(final FolderWorkflow workflow) throws Exception {
+                applyUnEmbargoToFolderDocuments(recurseSubFolders);
+                return null;
+            }
+        };
+    }
+
+    private void applyEmbargoToFolderDocuments(final boolean recurse) throws RepositoryException {
+        final Node folderNode = ((WorkflowDescriptorModel) getDefaultModel()).getNode();
+        final javax.jcr.Session jcrSession = getJcrSession();
+        final WorkflowManager wfManager = ((HippoWorkspace) jcrSession.getWorkspace()).getWorkflowManager();
+        embargoFolder(folderNode, recurse, jcrSession.getUserID(), wfManager);
+    }
+
+    private void embargoFolder(final Node folder, final boolean recurse,
+                                final String userId, final WorkflowManager wfManager) throws RepositoryException {
+        final NodeIterator children = folder.getNodes();
+        while (children.hasNext()) {
+            final Node child = children.nextNode();
+            if (child.isNodeType(EmbargoConstants.HIPPO_HANDLE)) {
+                if (!child.isNodeType(EmbargoConstants.EMBARGO_MIXIN_NAME)) {
+                    embargoDocument(child, userId, wfManager);
+                }
+            } else if (recurse && child.isNodeType("hippostd:folder")) {
+                embargoFolder(child, true, userId, wfManager);
+            }
+        }
+    }
+
+    private void embargoDocument(final Node handle, final String userId, final WorkflowManager wfManager) {
+        final Node[] variants;
+        try {
+            variants = EmbargoUtils.getDocumentVariants(handle);
+        } catch (RepositoryException e) {
+            log.error("Could not get variants for document at {}", handle, e);
+            return;
+        }
+        if (variants.length == 0) {
+            return;
+        }
+        try {
+            final Workflow wf = wfManager.getWorkflow("embargo", variants[0]);
+            if (wf instanceof EmbargoWorkflow) {
+                ((EmbargoWorkflow) wf).addEmbargo(userId, handle.getIdentifier(), null);
+            }
+        } catch (Exception e) {
+            log.error("Failed to set embargo on document at {}", handle, e);
+        }
+    }
+
+    private void applyUnEmbargoToFolderDocuments(final boolean recurse) throws RepositoryException {
+        final Node folderNode = ((WorkflowDescriptorModel) getDefaultModel()).getNode();
+        final javax.jcr.Session jcrSession = getJcrSession();
+        final WorkflowManager wfManager = ((HippoWorkspace) jcrSession.getWorkspace()).getWorkflowManager();
+        unembargoFolder(folderNode, recurse, wfManager);
+    }
+
+    private void unembargoFolder(final Node folder, final boolean recurse,
+                                  final WorkflowManager wfManager) throws RepositoryException {
+        final NodeIterator children = folder.getNodes();
+        while (children.hasNext()) {
+            final Node child = children.nextNode();
+            if (child.isNodeType(EmbargoConstants.HIPPO_HANDLE)) {
+                if (child.isNodeType(EmbargoConstants.EMBARGO_MIXIN_NAME)) {
+                    unembargoDocument(child, wfManager);
+                }
+            } else if (recurse && child.isNodeType("hippostd:folder")) {
+                unembargoFolder(child, true, wfManager);
+            }
+        }
+    }
+
+    private void unembargoDocument(final Node handle, final WorkflowManager wfManager) {
+        final Node[] variants;
+        try {
+            variants = EmbargoUtils.getDocumentVariants(handle);
+        } catch (RepositoryException e) {
+            log.error("Could not get variants for document at {}", handle, e);
+            return;
+        }
+        if (variants.length == 0) {
+            return;
+        }
+        try {
+            final Workflow wf = wfManager.getWorkflow("embargo", variants[0]);
+            if (wf instanceof EmbargoWorkflow) {
+                ((EmbargoWorkflow) wf).removeEmbargo(handle.getIdentifier());
+            }
+        } catch (Exception e) {
+            log.error("Failed to remove embargo on document at {}", handle, e);
+        }
+    }
+
+    private boolean currentUserCanEmbargo() {
+        final javax.jcr.Session jcrSession = getJcrSession();
+        final String userId = jcrSession.getUserID();
+        javax.jcr.Session configSession = null;
+        try {
+            configSession = jcrSession.getRepository().login(JvmCredentials.getCredentials("configuser"));
+            final boolean isAdmin = EmbargoUtils.isAdminUser(configSession, userId);
+            final String[] embargoGroups = EmbargoUtils.getCurrentUserEmbargoEnabledGroups(configSession, userId);
+            return isAdmin || embargoGroups.length > 0;
+        } catch (RepositoryException e) {
+            log.error("Error checking embargo group membership for user {}", userId, e);
+            return false;
+        } finally {
+            if (configSession != null) {
+                configSession.logout();
+            }
+        }
+    }
+
+    private javax.jcr.Session getJcrSession() {
+        return ((UserSession) Session.get()).getJcrSession();
+    }
+}

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoFolderWorkflowPlugin.properties
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoFolderWorkflowPlugin.properties
@@ -1,0 +1,7 @@
+embargo-all-in-folder-label=Embargo all in folder
+embargo-all-folder-title=Embargo all in folder
+embargo-all-confirm-text=This will embargo all documents in the selected folder.
+unembargo-all-in-folder-label=Unembargo all in folder
+unembargo-all-folder-title=Unembargo all in folder
+unembargo-all-confirm-text=This will remove embargo from all embargoed documents in the selected folder.
+recurse-sub-folders-label=Include sub-folders

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoFolderWorkflowPlugin_nl.properties
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoFolderWorkflowPlugin_nl.properties
@@ -1,0 +1,7 @@
+embargo-all-in-folder-label=Embargo alles in map
+embargo-all-folder-title=Embargo alles in map
+embargo-all-confirm-text=Dit zal embargo plaatsen op alle documenten in de geselecteerde map.
+unembargo-all-in-folder-label=Hef embargo op voor alles in map
+unembargo-all-folder-title=Hef embargo op voor alles in map
+unembargo-all-confirm-text=Dit zal embargo verwijderen van alle documenten met embargo in de geselecteerde map.
+recurse-sub-folders-label=Inclusief submappen

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/EmbargoListColumnProviderPlugin.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/EmbargoListColumnProviderPlugin.java
@@ -34,6 +34,7 @@ import org.hippoecm.frontend.plugins.standards.list.ListColumn;
 import org.onehippo.forge.embargo.frontend.plugins.cms.browse.list.comparators.EmbargoDocumentViewComparator;
 import org.onehippo.forge.embargo.frontend.plugins.cms.browse.list.resolvers.EmbargoAttributeRenderer;
 import org.onehippo.forge.embargo.frontend.plugins.cms.browse.list.resolvers.EmbargoDocumentView;
+import org.onehippo.forge.embargo.frontend.plugins.cms.browse.list.resolvers.EmbargoStatusIconRenderer;
 
 /**
  * Plugin showing embargo related columns in the document list view
@@ -58,7 +59,14 @@ public class EmbargoListColumnProviderPlugin extends AbstractListColumnProviderP
 
     @Override
     public List<ListColumn<Node>> getColumns() {
-        return new ArrayList<>();
+        List<ListColumn<Node>> columns = new ArrayList<>();
+
+        ListColumn<Node> statusColumn = new ListColumn<>(new ClassResourceModel("doclisting-embargo-status", getClass()), "embargo-status");
+        statusColumn.setCssClass("doclisting-embargo-status");
+        statusColumn.setRenderer(new EmbargoStatusIconRenderer());
+        columns.add(statusColumn);
+
+        return columns;
     }
 
     @Override

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/EmbargoListColumnProviderPlugin.properties
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/EmbargoListColumnProviderPlugin.properties
@@ -1,2 +1,3 @@
+doclisting-embargo-status=
 doclisting-embargo-groups=Embargo groups
 doclisting-embargo-expiration-date=Embargo expiration

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/EmbargoListColumnProviderPlugin_nl.properties
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/EmbargoListColumnProviderPlugin_nl.properties
@@ -1,2 +1,3 @@
+doclisting-embargo-status=
 doclisting-embargo-groups=Embargo groepen
 doclisting-embargo-expiration-date=Embargo expiratie

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/resolvers/EmbargoDocumentView.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/resolvers/EmbargoDocumentView.java
@@ -54,10 +54,16 @@ public class EmbargoDocumentView implements IObservable, IDetachable {
     private transient String[] embargoGroups;
     private transient String joinedEmbargoGroups;
     private transient Calendar expirationDate;
+    private transient boolean embargoed;
 
     public EmbargoDocumentView(JcrNodeModel nodeModel) {
         this.nodeModel = nodeModel;
         observable = new Observable(nodeModel);
+    }
+
+    public boolean isEmbargoed() {
+        load();
+        return embargoed;
     }
 
     public String[] getEmbargoGroups() {
@@ -77,7 +83,7 @@ public class EmbargoDocumentView implements IObservable, IDetachable {
 
     public void detach() {
         loaded = false;
-
+        embargoed = false;
         embargoGroups = null;
 
         nodeModel.detach();
@@ -108,6 +114,7 @@ public class EmbargoDocumentView implements IObservable, IDetachable {
                         }
                     }
                     if (handleNode != null) {
+                        embargoed = EmbargoUtils.isEmbargoed(handleNode);
                         if (handleNode.hasProperty(EmbargoConstants.EMBARGO_GROUP_PROPERTY_NAME)) {
                             Value[] groups = handleNode.getProperty(EmbargoConstants.EMBARGO_GROUP_PROPERTY_NAME).getValues();
                             embargoGroups = new String[groups.length];

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/resolvers/EmbargoStatusIconRenderer.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/resolvers/EmbargoStatusIconRenderer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onehippo.forge.embargo.frontend.plugins.cms.browse.list.resolvers;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.basic.Label;
+import org.hippoecm.frontend.model.JcrNodeModel;
+import org.hippoecm.frontend.plugins.standards.icon.HippoIcon;
+import org.hippoecm.frontend.plugins.standards.list.resolvers.AbstractNodeRenderer;
+import org.hippoecm.frontend.skin.Icon;
+
+/**
+ * Renders a lock icon for embargoed documents in the document list view,
+ * or nothing for documents that are not embargoed.
+ */
+public class EmbargoStatusIconRenderer extends AbstractNodeRenderer {
+
+    @Override
+    protected Component getViewer(final String id, final Node node) throws RepositoryException {
+        final EmbargoDocumentView view = new EmbargoDocumentView(new JcrNodeModel(node));
+        if (view.isEmbargoed()) {
+            return HippoIcon.fromSprite(id, Icon.LOCKED);
+        }
+        return new Label(id).setVisible(false);
+    }
+}

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/style.css
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/style.css
@@ -13,6 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+.hippo-list-documents > tbody > tr > td.doclisting-embargo-status,
+.hippo-list-documents > thead > tr > th.doclisting-embargo-status {
+  width: 32px;
+  min-width: 32px;
+  text-align: center;
+  padding: 0;
+}
+
 .hippo-list-documents > tbody > tr > td.doclisting-embargo-groups, .hippo-list-documents > thead > tr > th.doclisting-embargo-groups {
   width: 280px;
   min-width: 160px;

--- a/demo/conf/log4j2-dev.xml
+++ b/demo/conf/log4j2-dev.xml
@@ -41,6 +41,11 @@
       </Policies>
     </RollingFile>
 
+    <!-- embargo-debug.log (no filter) -->
+    <File name="embargo-debug" fileName="${sys:catalina.base}/logs/embargo-debug.log" append="false">
+      <PatternLayout pattern="%d{HH:mm:ss} %-5p %t [%C{1}.%M:%L] %m%n"/>
+    </File>
+
     <!-- console -->
     <Console name="console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss} %-5p %t [%C{1}.%M:%L] %m%n"/>
@@ -146,6 +151,12 @@
 
     <!-- project logging -->
     <Logger name="org.example" level="debug"/>
+
+    <!-- embargo forge debugging -->
+    <Logger additivity="false" name="org.onehippo.forge.embargo" level="warn">
+      <AppenderRef ref="embargo-debug"/>
+      <AppenderRef ref="console"/>
+    </Logger>
 
     <Root level="warn">
       <AppenderRef ref="site"/>

--- a/repository/src/main/java/org/onehippo/forge/embargo/repository/EmbargoUtils.java
+++ b/repository/src/main/java/org/onehippo/forge/embargo/repository/EmbargoUtils.java
@@ -61,6 +61,10 @@ public final class EmbargoUtils {
         return embargoEnabledUserGroups.toArray(new String[embargoEnabledUserGroups.size()]);
     }
 
+    public static boolean isEmbargoed(Node handleNode) throws RepositoryException {
+        return handleNode != null && handleNode.isNodeType(EmbargoConstants.EMBARGO_MIXIN_NAME);
+    }
+
     public static boolean isAdminUser(Session session, String userIdentity) {
         String[] allUserGroups = getAllUserGroups(session, userIdentity);
         for (final String allUserGroup : allUserGroups) {

--- a/repository/src/main/resources/hcm-config/workflow/embargo-folder-renderer.yaml
+++ b/repository/src/main/resources/hcm-config/workflow/embargo-folder-renderer.yaml
@@ -1,0 +1,22 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:workflows/threepane/folder/frontend:renderer/embargoAll:
+      jcr:primaryType: frontend:plugin
+      plugin.class: org.onehippo.forge.embargo.frontend.plugins.EmbargoFolderWorkflowPlugin
+      wicket.id: ${item}
+    /hippo:configuration/hippo:workflows/threepane/folder-extended/frontend:renderer/embargoAll:
+      jcr:primaryType: frontend:plugin
+      plugin.class: org.onehippo.forge.embargo.frontend.plugins.EmbargoFolderWorkflowPlugin
+      wicket.id: ${item}
+    /hippo:configuration/hippo:workflows/threepane/folder-permissions/frontend:renderer/embargoAll:
+      jcr:primaryType: frontend:plugin
+      plugin.class: org.onehippo.forge.embargo.frontend.plugins.EmbargoFolderWorkflowPlugin
+      wicket.id: ${item}
+    /hippo:configuration/hippo:workflows/threepane/directory/frontend:renderer/embargoAll:
+      jcr:primaryType: frontend:plugin
+      plugin.class: org.onehippo.forge.embargo.frontend.plugins.EmbargoFolderWorkflowPlugin
+      wicket.id: ${item}
+    /hippo:configuration/hippo:workflows/threepane/directory-extended/frontend:renderer/embargoAll:
+      jcr:primaryType: frontend:plugin
+      plugin.class: org.onehippo.forge.embargo.frontend.plugins.EmbargoFolderWorkflowPlugin
+      wicket.id: ${item}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -152,6 +152,13 @@
 
     <dependency>
       <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-cms-workflow-repository</artifactId>
+      <version>${hippo.cms.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
       <artifactId>hippo-repository-modules</artifactId>
       <version>${hippo.repository.version}</version>
       <scope>test</scope>

--- a/tests/src/test/java/org/onehippo/forge/embargo/repository/EmbargoUtilsTest.java
+++ b/tests/src/test/java/org/onehippo/forge/embargo/repository/EmbargoUtilsTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.onehippo.forge.embargo.repository.EmbargoConstants.EMBARGO_MIXIN_NAME;
 import static org.onehippo.forge.embargo.repository.EmbargoConstants.EMBARGO_SCHEDULE_REQUEST_NODE_NAME;
 import static org.onehippo.forge.embargo.repository.EmbargoConstants.HIPPOSCHED_TRIGGERS_DEFAULT;
 import static org.onehippo.forge.embargo.repository.EmbargoConstants.HIPPOSCHED_TRIGGERS_DEFAULT_PROPERTY_FIRETIME;
@@ -98,6 +99,29 @@ public class EmbargoUtilsTest {
         Node mockedeNode = new MockNode("/content");
         final Node[] documentVariants = EmbargoUtils.getDocumentVariants(mockedeNode);
         assertEquals(documentVariants.length, 0);
+    }
+
+    @Test
+    public void isEmbargoed_returnsTrue_whenHandleHasEmbargoMixin() throws Exception {
+        Node mockHandle = createMock(Node.class);
+        expect(mockHandle.isNodeType(EMBARGO_MIXIN_NAME)).andReturn(true);
+        replay(mockHandle);
+
+        assertTrue(EmbargoUtils.isEmbargoed(mockHandle));
+    }
+
+    @Test
+    public void isEmbargoed_returnsFalse_whenHandleLacksEmbargoMixin() throws Exception {
+        Node mockHandle = createMock(Node.class);
+        expect(mockHandle.isNodeType(EMBARGO_MIXIN_NAME)).andReturn(false);
+        replay(mockHandle);
+
+        assertFalse(EmbargoUtils.isEmbargoed(mockHandle));
+    }
+
+    @Test
+    public void isEmbargoed_returnsFalse_whenHandleIsNull() throws Exception {
+        assertFalse(EmbargoUtils.isEmbargoed(null));
     }
 
     @Test


### PR DESCRIPTION
Editors can now embargo or unembargo all documents in a folder in one action, mirroring the existing publish-all behaviour. A confirmation dialog with an optional recurse-into-subfolders checkbox is shown before any changes are applied.

- EmbargoFolderWorkflowPlugin registers two StdWorkflow menu items (lock/unlock icons) visible only to users with embargo permissions.
- EmbargoAllFolderDialog is parameterised with title/message models so it is shared by both actions without duplication.
- HCM YAML registers the plugin in all five threepane renderer clusters (folder, folder-extended, folder-permissions, directory, directory-extended) so it appears for all user roles.
- hippo-cms-workflow-repository added as test-scoped dependency so HCM can resolve the folder-permissions ancestor node during tests.

(co-authored with Claude Code)