### PR TITLE
FORGE-587: Upgrade Embargo to BrXM v17 (9.0.0-SNAPSHOT)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Bloomreach Forge Embargo Plugin
-Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
 This product includes software developed by:
 Bloomreach B.V., Amsterdam, The Netherlands (http://www.bloomreach.com/);

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.bloomreach.forge.embargo</groupId>
     <artifactId>embargo</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Embargo Plugin CMS</name>

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoWorkflowPlugin.html
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoWorkflowPlugin.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoWorkflowPlugin.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/EmbargoWorkflowPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/ScheduleDialog.html
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/ScheduleDialog.html
@@ -1,5 +1,5 @@
 <!--
-  * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
   *
   * Licensed under the Apache License, Version 2.0 (the  "License");
   * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/ScheduleDialog.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/ScheduleDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/SetEmbargoDialog.css
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/SetEmbargoDialog.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/SetEmbargoDialog.html
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/SetEmbargoDialog.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/SetEmbargoDialog.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/SetEmbargoDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/EmbargoListColumnProviderPlugin.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/EmbargoListColumnProviderPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/comparators/EmbargoDocumentViewComparator.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/comparators/EmbargoDocumentViewComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/resolvers/EmbargoAttributeRenderer.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/resolvers/EmbargoAttributeRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/resolvers/EmbargoDocumentView.java
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/resolvers/EmbargoDocumentView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2026 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/style.css
+++ b/cms/src/main/java/org/onehippo/forge/embargo/frontend/plugins/cms/browse/list/style.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>demo-cms-dependencies</artifactId>
   <packaging>pom</packaging>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>demo-cms</artifactId>
   <packaging>war</packaging>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>demo-essentials</artifactId>
   <packaging>war</packaging>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>17.0.0</version>
+    <version>17.1.1</version>
   </parent>
 
   <name>demo</name>
@@ -63,7 +63,7 @@
     <!--***START temporary override of versions*** -->
     <!-- ***END temporary override of versions*** -->
     <bloomreach.forge.embargo.version>${project.version}</bloomreach.forge.embargo.version>
-    <essentials.version>17.0.0</essentials.version>
+    <essentials.version>17.1.1</essentials.version>
 
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
 

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.7.1</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>demo</name>
   <description>demo</description>
   <groupId>org.example</groupId>
   <artifactId>demo</artifactId>
-  <version>8.0.2</version>
+  <version>9.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!-- 
@@ -63,7 +63,7 @@
     <!--***START temporary override of versions*** -->
     <!-- ***END temporary override of versions*** -->
     <bloomreach.forge.embargo.version>${project.version}</bloomreach.forge.embargo.version>
-    <essentials.version>16.0.0</essentials.version>
+    <essentials.version>17.0.0</essentials.version>
 
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
 
@@ -82,7 +82,7 @@
     <repository>
 	  <id>bloomreach-forge</id>
 	  <name>Bloomreach Forge maven 2 repository.</name>
-	  <url>http://maven.bloomreach.com/repository/maven2-forge/</url>
+	  <url>https://maven.bloomreach.com/repository/maven2-forge/</url>
 	  <snapshots>
 	    <enabled>false</enabled>
 	  </snapshots>

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo-repository-data</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>demo Repository Data For Application</name>

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo-repository-data</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>demo Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>demo Repository Data</name>

--- a/demo/repository-data/site-development/pom.xml
+++ b/demo/repository-data/site-development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo-repository-data</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>demo Repository Data For Site Development</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo-repository-data</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>demo Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo-repository-data</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>demo Repository Data Web Files</name>

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo-site</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>demo-components</artifactId>
   <packaging>jar</packaging>

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>demo-site</artifactId>
   <packaging>pom</packaging>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>demo-site</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>demo-webapp</artifactId>
   <packaging>war</packaging>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.example</groupId>
       <artifactId>demo-components</artifactId>
-      <version>8.0.2</version>
+      <version>9.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7.hst.toolkit-resources.addon</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,13 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.7.1</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>Bloomreach Embargo Plugin</name>
   <groupId>org.bloomreach.forge.embargo</groupId>
   <artifactId>embargo</artifactId>
-  <version>8.0.2</version>
+  <version>9.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/bloomreach-forge/embargo</url>
 
@@ -80,7 +80,7 @@
 
   <issueManagement>
     <system>JIRA</system>
-    <url>https://issues.onehippo.com/projects/FORGE</url>
+    <url>https://bloomreach.atlassian.net/projects/FORGE</url>
   </issueManagement>
 
   <licenses>
@@ -138,7 +138,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
+        <version>${junit4.version}</version>
         <scope>test</scope>
       </dependency>
 
@@ -181,7 +181,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <release>17</release>
+          <release>21</release>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>17.0.0</version>
+    <version>17.1.1</version>
   </parent>
 
   <name>Bloomreach Embargo Plugin</name>
@@ -31,7 +31,7 @@
   <url>https://github.com/bloomreach-forge/embargo</url>
 
   <properties>
-    <maven.plugin.jxr.version>3.4.0</maven.plugin.jxr.version>
+    <maven.plugin.jxr.version>3.6.0</maven.plugin.jxr.version>
  </properties>
 
   <developers>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.bloomreach.forge.embargo</groupId>
     <artifactId>embargo</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Embargo Plugin Repository</name>

--- a/repository/src/main/java/org/onehippo/forge/embargo/repository/EmbargoConstants.java
+++ b/repository/src/main/java/org/onehippo/forge/embargo/repository/EmbargoConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/onehippo/forge/embargo/repository/EmbargoUtils.java
+++ b/repository/src/main/java/org/onehippo/forge/embargo/repository/EmbargoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/onehippo/forge/embargo/repository/modules/EmbargoWorkflowEventsProcessingModule.java
+++ b/repository/src/main/java/org/onehippo/forge/embargo/repository/modules/EmbargoWorkflowEventsProcessingModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2026 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/onehippo/forge/embargo/repository/workflow/EmbargoWorkflow.java
+++ b/repository/src/main/java/org/onehippo/forge/embargo/repository/workflow/EmbargoWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/onehippo/forge/embargo/repository/workflow/EmbargoWorkflowImpl.java
+++ b/repository/src/main/java/org/onehippo/forge/embargo/repository/workflow/EmbargoWorkflowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2026 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   <skin>
     <groupId>org.bloomreach.forge.mavenskin</groupId>
     <artifactId>forge-maven-skin</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
   </skin>
 
   <custom>

--- a/src/site/xdoc/embargo-groups.xml
+++ b/src/site/xdoc/embargo-groups.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -49,6 +49,10 @@
                         <tr>
                             <th>Embargo Plugin</th>
                             <th>Bloomreach Release</th>
+                        </tr>
+                        <tr>
+                            <td>9.x</td>
+                            <td>17.x</td>
                         </tr>
                         <tr>
                             <td>8.x</td>

--- a/src/site/xdoc/install.xml
+++ b/src/site/xdoc/install.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,6 +20,17 @@
   </properties>
   <body>
     <section name="Release Notes">
+      <subsection name="9.0.0">
+        <p class="smallinfo">
+          Released: 15 July 2026
+        </p>
+        <ul>
+          <li>
+            <a href="https://bloomreach.atlassian.net/browse/FORGE-587">FORGE-587</a><br/>
+            Upgrade to Bloomreach Experience Manager 17
+          </li>
+        </ul>
+      </subsection>
       <subsection name="8.0.1">
         <p class="smallinfo">
           Released: 12 Mar 2026

--- a/src/site/xdoc/screenshots.xml
+++ b/src/site/xdoc/screenshots.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/site/xdoc/usage.xml
+++ b/src/site/xdoc/usage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.bloomreach.forge.embargo</groupId>
     <artifactId>embargo</artifactId>
-    <version>8.0.2</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Embargo Plugin Tests</name>
@@ -63,6 +63,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tests/src/test/java/org/onehippo/forge/embargo/repository/EmbargoUtilsTest.java
+++ b/tests/src/test/java/org/onehippo/forge/embargo/repository/EmbargoUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/java/org/onehippo/forge/embargo/tests/EmbargoSecurityDomainsTest.java
+++ b/tests/src/test/java/org/onehippo/forge/embargo/tests/EmbargoSecurityDomainsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/java/org/onehippo/forge/embargo/tests/TestConstants.java
+++ b/tests/src/test/java/org/onehippo/forge/embargo/tests/TestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Bump parent hippo-cms7-release: 16.7.1 → 17.0.0
- Bump project version: 8.0.2 → 9.0.0-SNAPSHOT
- Update essentials.version: 16.0.0 → 17.0.0
- Replace ${junit.version} with ${junit4.version} (removed in v17 parent)
- Add junit-vintage-engine to run existing JUnit 4 tests on JUnit Platform
- Fix demo forge repo URL: HTTP → HTTPS
- Update issueManagement URL: onehippo.com → bloomreach.atlassian.net
- Bump maven-javadoc-plugin release target: 17 → 21